### PR TITLE
Use multi-stage builds for plotter and API.

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20
+FROM golang:1.20.3-alpine3.17 AS build
 
 WORKDIR /usr/src/app
 
@@ -6,6 +6,10 @@ COPY ./api/go.mod ./api/go.sum ./
 RUN go mod download && go mod verify
 
 COPY . .
-RUN go build -v -o /usr/local/bin/ ./api/...
+RUN go build -v -o api ./api/...
+
+FROM alpine:3.17
+
+COPY --from=build /usr/src/app/api /usr/local/bin/
 
 CMD [ "buddhabrot-go" ]

--- a/plotter/Dockerfile
+++ b/plotter/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20
+FROM golang:1.20.3-alpine3.17 AS build
 
 WORKDIR /usr/src/app
 
@@ -6,6 +6,10 @@ COPY ./plotter/go.mod ./plotter/go.sum ./
 RUN go mod download && go mod verify
 
 COPY . .
-RUN go build -v -o /usr/local/bin/ ./plotter/...
+RUN go build -v -o plotter ./plotter/...
+
+FROM alpine:3.17
+
+COPY --from=build /usr/src/app/plotter /usr/local/bin/
 
 CMD [ "plotter" ]


### PR DESCRIPTION
`alpine:3.17`:

- API 16.44 MB
- Plotter 14.05 MB