### PR TITLE
Set location header in plot response.

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"log"
 	"net/http"
+	"net/url"
 	"strconv"
 
 	"github.com/ebeeton/buddhabrot-go/shared/database"
@@ -74,6 +75,13 @@ func plotRequest(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
 	queue.Enqueue(buf.Bytes())
 	log.Println("Request queued.")
 
+	// Set the response location header with the ID.
+	ids := strconv.FormatInt(id, 10)
+	if l, err := url.JoinPath(r.URL.String(), ids); err != nil {
+		log.Fatal(err)
+	} else {
+		w.Header().Add("Location", l)
+	}
 	w.WriteHeader(http.StatusCreated)
 	json.NewEncoder(w).Encode(req)
 }


### PR DESCRIPTION
Closes #34.
```
*   Trying 127.0.0.1:3000...
* Connected to localhost (127.0.0.1) port 3000 (#0)
> POST /api/plots HTTP/1.1
> Host: localhost:3000
> User-Agent: curl/7.81.0
> Accept: */*
> Content-Type: application/json
> Content-Length: 514
>
* Mark bundle as not supporting multiuse
< HTTP/1.1 201 Created
< Location: /api/plots/37
< Date: Fri, 14 Apr 2023 21:27:08 GMT
< Content-Length: 322
< Content-Type: text/plain; charset=utf-8
<
{"Id":37,"Plot":{"SampleSize":10000000,"MaxIterations":5000,"Region":{"MinReal":-2,"MaxReal":2,"MinImag":-2,"MaxImag":2},"Width":200,"Height":200,"Gradient":[{"Color":"#000000","Position":0},{"Color":"#ff8000","Position":0.5},{"Color":"#ffff00","Position":0.75},{"Color":"#FFFFFF","Position":1}],"DumpCounterFile":false}}
* Connection #0 to host localhost left intact
```